### PR TITLE
(Converting .view op to .reshape) maintain main.py with upstream pyto…

### DIFF
--- a/pytorch_examples/imagenet/main.py
+++ b/pytorch_examples/imagenet/main.py
@@ -369,7 +369,7 @@ def accuracy(output, target, topk=(1,)):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+            correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 


### PR DESCRIPTION
…rch examples

Mainline pytorch examples has this change:
https://github.com/pytorch/examples/blob/master/imagenet/main.py#L423

Pytorch 1.5.0 also mention this becoming an incompatible change / known issue later:
https://github.com/pytorch/pytorch/releases/tag/v1.5.0